### PR TITLE
Use tempfile for test dir, use Path & PathBuf instead of String

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,19 +6,18 @@ description = "Export your Reddit Chats"
 readme = "README.md"
 license = "GPL-3.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+cached = "0.43.0"
 chrono = { version = "0.4.24", features = ["serde"] }
+clap = { version = "4.2.1", features = ["derive"] }
+console = { version = "0.15.5", features = ["windows-console-colors"] }
+inquire = "0.6.1"
+log = "0.4.0"
+pretty_env_logger = "0.4.0"
+regex = "1.7.3"
 reqwest = {version = "0.11.16", features = ["blocking", "multipart", "cookies", "gzip"]}
 serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0"
-clap = { version = "4.2.1", features = ["derive"] }
-regex = "1.7.3"
-urlencoding = "2.1.2"
-log = "0.4.0"
-pretty_env_logger = "0.4.0"
-inquire = "0.6.1"
-cached = "0.43.0"
-console = { version = "0.15.5", features = ["windows-console-colors"] }
+tempfile = "3"
 url = "2.3.1"
+urlencoding = "2.1.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 //! Argument Parser
 
+use std::path::PathBuf;
+
 pub use clap::{Args, Parser, Subcommand};
 
 /// CLI argument parser, see the Cli struct for the possible arguments
@@ -26,5 +28,5 @@ pub struct Cli {
 
     /// What folder to output to
     #[arg(short, long, default_value = "./out")]
-    pub out: String,
+    pub out: PathBuf,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use console::style;
 use export::export_saved_posts;
 use inquire::{self, Password, Text};
 use std::env;
-use std::path::PathBuf;
 
 // import other files
 mod ReAPI;
@@ -81,18 +80,18 @@ fn main() {
 
     // Handle output folder stuff
     // Deletes the output folder (we append the batches so this is necessary)
-    if PathBuf::from(&args.out).exists() {
+    if args.out.exists() {
         std::fs::remove_dir_all(&args.out).expect("Error deleting out folder");
     }
 
     // Creates out folders
     std::fs::create_dir(&args.out).unwrap();
-    std::fs::create_dir(format!("{}/messages", args.out)).unwrap();
-    std::fs::create_dir(format!("{}/saved_posts", args.out)).unwrap();
+    std::fs::create_dir(args.out.join("messages")).unwrap();
+    std::fs::create_dir(args.out.join("saved_posts")).unwrap();
 
     // Make sure there is an images folder to output to if images is true
     if args.images {
-        std::fs::create_dir(format!("{}/messages/images", args.out)).unwrap();
+        std::fs::create_dir(args.out.join("messages/images")).unwrap();
     }
 
     // Get list of rooms
@@ -113,15 +112,15 @@ fn main() {
     for room in rooms {
         for format in export_formats.clone() {
             match format {
-                "txt" => export::export_room_chats_txt(room.to_owned(), args.out.clone()),
-                "json" => export::export_room_chats_json(room.to_owned(), args.out.clone()),
-                "csv" => export::export_room_chats_csv(room.to_owned(), args.out.clone()),
-                "images" => export::export_room_images(room.to_owned(), args.out.clone()),
+                "txt" => export::export_room_chats_txt(room.to_owned(), &args.out),
+                "json" => export::export_room_chats_json(room.to_owned(), &args.out),
+                "csv" => export::export_room_chats_csv(room.to_owned(), &args.out),
+                "images" => export::export_room_images(room.to_owned(), &args.out),
                 _ => println!("Not valid Format"),
             }
         }
     }
 
     // Export Saved posts
-    export_saved_posts(saved_posts, export_formats, args.out.clone());
+    export_saved_posts(saved_posts, export_formats, &args.out);
 }


### PR DESCRIPTION
Tests in general shouldn't drop content into the current working directory, we can use `tempfile::tempdir()` to get a temporary directory to use for the output.

At the same time, adjust `String`s used as paths to be `&Path` or `PathBuf`.

This provides the env var `REXIT_TEST_OUT_DIR` to allow obtaining the test output in a non-temporary directory if desired by the developer.