### PR TITLE
Support all post image embeds & Performance improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,6 +669,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
+name = "html-escape"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,6 +1270,7 @@ dependencies = [
  "chrono",
  "clap",
  "console",
+ "html-escape",
  "inquire",
  "log",
  "pretty_env_logger",
@@ -1703,6 +1713,12 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,6 +1269,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "tokio",
  "url",
  "urlencoding",
 ]
@@ -1569,7 +1570,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ reqwest = {version = "0.11.*", features = ["blocking", "multipart", "cookies", "
 serde = { version = "1.0.*", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3"
+tokio = { version = "1.28.0", features = ["full"] }
 url = "2.3.*"
 urlencoding = "2.1.*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cached = "0.43.*"
 chrono = { version = "0.4.*", features = ["serde"] }
 clap = { version = "4.2.*", features = ["derive"] }
 console = { version = "0.15.*", features = ["windows-console-colors"] }
+html-escape = "0.2.13"
 inquire = "0.6.*"
 log = "0.4.*"
 pretty_env_logger = "0.4.*"

--- a/src/ReAPI/images.rs
+++ b/src/ReAPI/images.rs
@@ -2,8 +2,8 @@ use super::Client;
 use crate::exit;
 use console::style;
 use serde::Serialize;
-use url::Url;
 use std::path::PathBuf;
+use url::Url;
 
 #[derive(std::hash::Hash, Clone, Debug, Serialize)]
 pub struct Image {
@@ -35,25 +35,29 @@ impl Image {
 
 /// Gets images from a mxc:// URL as per [SPEC](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)
 pub async fn get_image(client: &Client, url: String, path: &std::path::Path) {
-    info!(target: "get_image", "Getting image: {}", url);
+    info!(target: "get_image", "Getting image: {}...", &url[0..30]);
     let mut url = url;
     let mut id: Option<String> = None;
     if url.starts_with("mxc") {
+        // Matrix images
         (url, id) = parse_matrix_image_url(url.as_str());
+        let data = client.reqwest_client.get(url.clone()).send().await.unwrap();
+        let path = path
+            .join(id.unwrap())
+            .with_extension(get_image_extension(data.headers()));
+
+        std::fs::write(path, data.bytes().await.unwrap().to_vec()).unwrap();
     } else {
+        // Litteraly any other image
         // Parse the image url to get the ID
         id = Some(Url::parse(&url).unwrap().path().to_string());
         id = Some(id.unwrap().replace("/", ""));
-        info!("{:#?}", id)
-        
+
+        let data = client.reqwest_client.get(url.clone()).send().await.unwrap();
+        let path = path.join(id.unwrap());
+
+        std::fs::write(path, data.bytes().await.unwrap().to_vec()).unwrap();
     }
-    info!("{:#?}", path);
-
-    let data = client.reqwest_client.get(url.clone()).send().await.unwrap();
-    let path = path.join(id.unwrap());
-
-    info!("filepath: {:#?}", path);
-    std::fs::write(path, data.bytes().await.unwrap().to_vec()).unwrap();
 }
 
 fn parse_matrix_image_url(url: &str) -> (String, Option<String>) {
@@ -112,14 +116,13 @@ mod tests {
     #[tokio::test]
     async fn get_image() {
         let client = super::super::new_client(true);
-        let _output = 
-                super::get_image(
-                    &client,
-                    "mxc://reddit.com/dwdprq7pxbva1/".to_string(),
-                    std::path::Path::new("./test_resources/ReAPI/images/get_images")
-                ).await;
-            
-    
+        let _output = super::get_image(
+            &client,
+            "mxc://reddit.com/dwdprq7pxbva1/".to_string(),
+            std::path::Path::new("./test_resources/ReAPI/images/get_images"),
+        )
+        .await;
+
         assert!(std::path::PathBuf::from(
             "./test_resources/test_cases/ReAPI/images/get_images/dwdprq7pxbva1.gif"
         )

--- a/src/ReAPI/mod.rs
+++ b/src/ReAPI/mod.rs
@@ -23,15 +23,15 @@ pub use users::get_user;
 pub use users::User;
 
 pub struct Client {
-    reqwest_client: reqwest::blocking::Client,
+    reqwest_client: reqwest::Client,
     bearer: Option<String>,
 }
 
 pub fn new_client(debug: bool) -> Client {
     // Build the client
-    let client: reqwest::blocking::Client;
+    let client: reqwest::Client;
     if debug {
-        client = reqwest::blocking::Client::builder()
+        client = reqwest::Client::builder()
             .cookie_store(true)
             .timeout(std::time::Duration::from_secs(60))
             .danger_accept_invalid_certs(true) // Used in development to trust a proxy
@@ -39,7 +39,7 @@ pub fn new_client(debug: bool) -> Client {
             .build()
             .expect("Error making Reqwest Client");
     } else {
-        client = reqwest::blocking::Client::builder()
+        client = reqwest::Client::builder()
             .cookie_store(true)
             .timeout(std::time::Duration::from_secs(60))
             .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.121 Safari/537.36")

--- a/src/ReAPI/rooms.rs
+++ b/src/ReAPI/rooms.rs
@@ -9,10 +9,10 @@ pub struct Room {
 }
 
 impl Room {
-    fn download(id: String, client: &Client) -> Room {
+    async fn download(id: String, client: &Client) -> Room {
         Room {
             id: id.clone(),
-            messages: download_messages(&client, id.clone()),
+            messages: download_messages(&client, id.clone()).await,
         }
     }
 
@@ -21,22 +21,23 @@ impl Room {
     }
 }
 
-fn download_messages(client: &Client, id: String) -> Option<Vec<super::Message>> {
-    Some(super::messages::list_messages(client, id))
+async fn download_messages(client: &Client, id: String) -> Option<Vec<super::Message>> {
+    Some(super::messages::list_messages(client, id).await)
 }
 
 /// Returns list of all rooms that the user is joined to as per [SPEC](https://spec.matrix.org/v1.6/client-server-api/#get_matrixclientv3directorylistroomroomid)
-pub fn download_rooms(client: &Client) -> Vec<Room> {
+pub async fn download_rooms(client: &Client) -> Vec<Room> {
     let resp = client
         .reqwest_client
         .get("https://matrix.redditspace.com/_matrix/client/v3/joined_rooms")
         .header("Authorization", format!("Bearer {}", client.bearer_token()))
         .send()
+        .await
         .expect("Failed to send HTTP request; to obtain rooms");
 
     // Parse json
     let json: Value =
-        serde_json::from_str(&resp.text().unwrap()).expect("Error parsing Rooms list JSON");
+        serde_json::from_str(&resp.text().await.unwrap()).expect("Error parsing Rooms list JSON");
 
     // Read rooms from json
     let rooms = json["joined_rooms"]
@@ -45,29 +46,34 @@ pub fn download_rooms(client: &Client) -> Vec<Room> {
         .to_owned();
 
     // Move rooms into a Vec<Room>
-    let rooms: Vec<Room> = rooms
+    let rooms = rooms
         .iter()
-        .map(|room| Room::download(room.to_string().replace("\"", ""), client))
-        .collect();
+        .map(move |room| {Room::download(room.to_string().replace("\"", ""), client)});
+    
+    let mut rooms_2: Vec<Room> = vec![];
+    for room in rooms {
+        rooms_2.push(room.await);
+    }
 
-    info!("Found {} room(s) ", rooms.len());
 
-    return rooms;
+    info!("Found {} room(s) ", rooms_2.len());
+
+    return rooms_2;
 }
 
 #[cfg(test)]
 mod tests {
-    #[test]
+    #[tokio::test]
     #[ignore = "creds"]
-    fn list_rooms() {
+    async fn list_rooms() {
         let (username, password) = get_login();
         let mut client = super::super::new_client(true);
 
-        client.login(username, password);
+        client.login(username, password).await;
 
         let rooms = super::download_rooms(&client);
 
-        println!("{:?}", rooms);
+        println!("{:?}", rooms.await);
     }
 
     fn get_login() -> (String, String) {

--- a/src/ReAPI/saved_posts.rs
+++ b/src/ReAPI/saved_posts.rs
@@ -18,7 +18,7 @@ pub struct Post {
     pub img_url: Vec<String>,
 }
 
-pub fn download_saved_posts(client: &Client, image_download: bool) -> Vec<Post> {
+pub async fn download_saved_posts(client: &Client, image_download: bool) -> Vec<Post> {
     info!("Getting Saved Posts");
 
     let mut after_token = String::new();
@@ -31,9 +31,10 @@ pub fn download_saved_posts(client: &Client, image_download: bool) -> Vec<Post> 
             .reqwest_client
             .get(url)
             .send()
+            .await
             .expect("Failed to send HTTP request");
 
-        let saved_posts: Result<Value, _> = serde_json::from_str(response.text().unwrap().as_str());
+        let saved_posts: Result<Value, _> = serde_json::from_str(response.text().await.unwrap().as_str());
         if saved_posts.is_err() {
             return vec![];
         }
@@ -54,7 +55,7 @@ pub fn download_saved_posts(client: &Client, image_download: bool) -> Vec<Post> 
                     let final_url = format!("https://i.redd.it{}", fixed_url.path());
 
                     if image_download {
-                        images::get_image(&client, final_url.clone());
+                        images::get_image(&client, final_url.clone(), &std::path::PathBuf::from("./out/images")).await;
                     }
 
                     images.push(final_url.to_owned())

--- a/src/ReAPI/users.rs
+++ b/src/ReAPI/users.rs
@@ -22,7 +22,8 @@ pub async fn get_user(client: &Client, id: String) -> User {
         .await
         .expect("Failed to send HTTP request");
 
-    let value: serde_json::Value = serde_json::from_str(response.text().await.unwrap().as_str()).unwrap();
+    let value: serde_json::Value =
+        serde_json::from_str(response.text().await.unwrap().as_str()).unwrap();
 
     debug!("Found user: {}", value["displayname"].clone());
 

--- a/src/ReAPI/users.rs
+++ b/src/ReAPI/users.rs
@@ -12,16 +12,17 @@ pub struct User {
     create = "{ SizedCache::with_size(10_000) }",
     convert = r#"{ format!("{}", id) }"#
 )]
-pub fn get_user(client: &Client, id: String) -> User {
+pub async fn get_user(client: &Client, id: String) -> User {
     let url = format!("https://matrix.redditspace.com/_matrix/client/r0/profile/{id}/displayname",);
 
     let response = client
         .reqwest_client
         .get(url)
         .send()
+        .await
         .expect("Failed to send HTTP request");
 
-    let value: serde_json::Value = serde_json::from_str(response.text().unwrap().as_str()).unwrap();
+    let value: serde_json::Value = serde_json::from_str(response.text().await.unwrap().as_str()).unwrap();
 
     debug!("Found user: {}", value["displayname"].clone());
 
@@ -34,13 +35,13 @@ pub fn get_user(client: &Client, id: String) -> User {
 #[cfg(test)]
 mod tests {
 
-    #[test]
-    fn get_user() {
+    #[tokio::test]
+    async fn get_user() {
         let client = super::super::new_client(true);
         let id = "@t2_9b09u6gps:reddit.com".to_string();
 
         let result = super::get_user(&client, id);
 
-        assert_eq!(result.displayname, "rexitTest");
+        assert_eq!(result.await.displayname, "rexitTest");
     }
 }

--- a/src/export.rs
+++ b/src/export.rs
@@ -22,20 +22,6 @@ pub fn export_room_chats_txt(room: ReAPI::Room, out_folder: &Path) {
             );
 
             output_buffer.push_str(line.as_str());
-        } else if let ReAPI::Content::Image(image) = message.content {
-            let image_text = format!("FILE: {}", image.id);
-
-            let line: String = format!(
-                "[{}] {}: {}\n",
-                message
-                    .timestamp
-                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-                    .to_string(),
-                message.author,
-                image_text
-            );
-
-            output_buffer.push_str(line.as_str());
         }
     }
 
@@ -73,18 +59,6 @@ pub fn export_room_chats_csv(room: ReAPI::Room, out_folder: &Path) {
                 message.author,
                 text
             );
-        } else if let ReAPI::Content::Image(image) = message.content {
-            let image_text = format!("FILE: {}", image.id);
-
-            line = format!(
-                "{}, {}, {},",
-                message
-                    .timestamp
-                    .to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-                    .to_string(),
-                message.author,
-                image_text
-            );
         }
 
         let mut file = OpenOptions::new()
@@ -95,19 +69,6 @@ pub fn export_room_chats_csv(room: ReAPI::Room, out_folder: &Path) {
 
         if let Err(e) = writeln!(file, "{}", line) {
             eprintln!("Couldn't write to file: {}", e);
-        }
-    }
-}
-
-/// Export images from chats
-pub fn export_room_images(room: ReAPI::Room, out_folder: &Path) {
-    for message in room.messages() {
-        if let ReAPI::Content::Image(image) = message.content {
-            std::fs::write(
-                out_folder.join(format!("messages/images/{}.{}", image.id, image.extension)),
-                image.data,
-            )
-            .unwrap();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,27 +88,23 @@ async fn main() {
     // Creates out folders
     std::fs::create_dir(&args.out).unwrap();
     std::fs::create_dir(args.out.join("messages")).unwrap();
-    std::fs::create_dir(args.out.join("images")).unwrap();
     std::fs::create_dir(args.out.join("saved_posts")).unwrap();
 
     // Make sure there is an images folder to output to if images is true
     if args.images {
         std::fs::create_dir(args.out.join("messages/images")).unwrap();
+        std::fs::create_dir(args.out.join("saved_posts/images")).unwrap();
     }
 
     // Get list of rooms
-    let rooms = ReAPI::download_rooms(&client).await;
+    let rooms = ReAPI::download_rooms(&client, args.images).await;
 
     // Gets saved posts
     let saved_posts = ReAPI::download_saved_posts(&client, args.images);
 
     // Export logic
     // Exports messages to files. Add image if its set to args
-    let mut export_formats: Vec<&str> = args.formats.split(",").collect();
-
-    if args.images == true {
-        export_formats.push("images")
-    }
+    let export_formats: Vec<&str> = args.formats.split(",").collect();
 
     // Export chats
     for room in rooms {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,8 @@ use cli::{Cli, Parser};
 /// Prepares the logger according to the `RUST_LOG` environment variable. If none set it is set to `INFO`
 /// Then according to the auth flow either username and password are inquired; or just a bearer token.
 /// It runs the sync function, and handles the export.
-fn main() {
+#[tokio::main]
+async fn main() {
     // Initialize logging
     // If no log level is set => set to info
     match env::var("RUST_LOG") {
@@ -58,7 +59,7 @@ fn main() {
 
         let username = std::env::var("REXIT_USERNAME").unwrap();
         let password = std::env::var("REXIT_PASSWORD").unwrap();
-        client.login(username, password);
+        client.login(username, password).await;
     } else {
         // Use the username password auth flow
         trace!("Password auth flow");
@@ -73,7 +74,7 @@ fn main() {
             .prompt()
             .expect("Error reading password");
 
-        client.login(username.to_owned(), password.to_owned());
+        client.login(username.to_owned(), password.to_owned()).await;
     }
 
     info!("Login Successful");
@@ -87,6 +88,7 @@ fn main() {
     // Creates out folders
     std::fs::create_dir(&args.out).unwrap();
     std::fs::create_dir(args.out.join("messages")).unwrap();
+    std::fs::create_dir(args.out.join("images")).unwrap();
     std::fs::create_dir(args.out.join("saved_posts")).unwrap();
 
     // Make sure there is an images folder to output to if images is true
@@ -95,7 +97,7 @@ fn main() {
     }
 
     // Get list of rooms
-    let rooms = ReAPI::download_rooms(&client);
+    let rooms = ReAPI::download_rooms(&client).await;
 
     // Gets saved posts
     let saved_posts = ReAPI::download_saved_posts(&client, args.images);
@@ -115,11 +117,12 @@ fn main() {
                 "txt" => export::export_room_chats_txt(room.to_owned(), &args.out),
                 "json" => export::export_room_chats_json(room.to_owned(), &args.out),
                 "csv" => export::export_room_chats_csv(room.to_owned(), &args.out),
-                "images" => export::export_room_images(room.to_owned(), &args.out),
                 _ => println!("Not valid Format"),
             }
         }
     }
+
+    let saved_posts = saved_posts.await;
 
     // Export Saved posts
     export_saved_posts(saved_posts, export_formats, &args.out);


### PR DESCRIPTION
* Now ReAPI will save images to disk itself, yes this is not quite in the sprit of having a seperate library, but it allows us to use async to increace the speed. 
* Now ReAPI gets the post image from the preview itself, so it now supports all image sites (eg. imgur (RIP)) natively