### PR TITLE
Not redownload all images between runs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "rexit"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "cached",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -94,6 +94,18 @@ To access these:
 $ cargo doc --open
 ```
 
+## Common Errors
+**Q:** Some images are not downloading, the console says `Image was already downloaded`; Skipping``.
+
+**A:** Delete the `imageLog.txt` file from the out folder.
+
+---
 In general all contributions are welcome. I would appreciate if you'd create an issue beforehand, in order for me to plan things out nicely.
+
+
+**Note To Reddit:** Care was taken to ensure as little API requests are made as possible.
+- Username requests are cached locally, and an option is provided to not gather the usernames
+- A log of already downloaded images is kept to prevent downloading images multiple times
+
 ## License
 [GNU General Public License, Version 3](./LICENSE)

--- a/src/ReAPI/images.rs
+++ b/src/ReAPI/images.rs
@@ -36,10 +36,17 @@ impl Image {
 
 /// Gets images from a mxc:// URL as per [SPEC](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)
 pub async fn get_image(client: &Client, url: String, out: PathBuf, path: &std::path::Path) {
-    info!(target: "get_image", "Getting image: {}...", &url[0..30]);
     let mut url = url;
     let mut id: Option<String> = None;
-
+    
+    
+    if image_log::check_image_log(out.clone(), url.clone()) {
+        // Image was already downloaded
+        info!("Image was already downloaded; Skipping");
+        return;
+    }
+    
+    info!(target: "get_image", "Getting image: {}...", &url[0..30]);
     image_log::write_image_log(out, url.clone());
 
 

--- a/src/ReAPI/images.rs
+++ b/src/ReAPI/images.rs
@@ -1,10 +1,10 @@
 use super::Client;
-use crate::exit;
+use crate::{exit, image_log};
 use console::style;
+use log::{error, info};
 use serde::Serialize;
 use std::path::PathBuf;
 use url::Url;
-use log::{error, info};
 
 #[derive(std::hash::Hash, Clone, Debug, Serialize)]
 pub struct Image {
@@ -35,10 +35,14 @@ impl Image {
 }
 
 /// Gets images from a mxc:// URL as per [SPEC](https://spec.matrix.org/v1.6/client-server-api/#get_matrixmediav3downloadservernamemediaid)
-pub async fn get_image(client: &Client, url: String, path: &std::path::Path) {
+pub async fn get_image(client: &Client, url: String, out: PathBuf, path: &std::path::Path) {
     info!(target: "get_image", "Getting image: {}...", &url[0..30]);
     let mut url = url;
     let mut id: Option<String> = None;
+
+    image_log::write_image_log(out, url.clone());
+
+
     if url.starts_with("mxc") {
         // Matrix images
         (url, id) = parse_matrix_image_url(url.as_str());
@@ -110,28 +114,4 @@ fn get_image_extension(headers: &reqwest::header::HeaderMap) -> String {
     }
 
     return extension.unwrap();
-}
-
-#[cfg(test)]
-mod tests {
-    #[tokio::test]
-    async fn get_image() {
-        let client = super::super::new_client(true);
-        let _output = super::get_image(
-            &client,
-            "mxc://reddit.com/dwdprq7pxbva1/".to_string(),
-            std::path::Path::new("./test_resources/test_cases/ReAPI/images/get_images"),
-        )
-        .await;
-
-        assert!(std::path::PathBuf::from(
-            "./test_resources/test_cases/ReAPI/images/get_images/dwdprq7pxbva1.gif"
-        )
-        .exists());
-
-        std::fs::remove_file(
-            "./test_resources/test_cases/ReAPI/images/get_images/dwdprq7pxbva1.gif",
-        )
-        .expect("Could not remove downloaded file");
-    }
 }

--- a/src/ReAPI/messages.rs
+++ b/src/ReAPI/messages.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::{images, Client};
 use chrono::{TimeZone, Utc};
 use log::debug;
@@ -52,6 +54,7 @@ pub async fn list_messages(
     id: String,
     image_download: bool,
     no_usernames: bool,
+    out: PathBuf
 ) -> Vec<Message> {
     let mut output: Vec<Message> = vec![];
     let mut batch: String = String::new();
@@ -100,6 +103,7 @@ pub async fn list_messages(
                     images::get_image(
                         &client,
                         message.content.url.unwrap(),
+                        out.clone(),
                         &std::path::PathBuf::from("./out/messages/images"),
                     )
                     .await;
@@ -132,6 +136,8 @@ fn unix_millis_to_utc(unix_time: i64) -> chrono::DateTime<Utc> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::super::new_client;
 
     #[tokio::test]
@@ -143,9 +149,9 @@ mod tests {
 
         client.login(username, password).await;
 
-        let rooms = super::super::download_rooms(&client, true);
+        let rooms = super::super::download_rooms(&client, true, false, PathBuf::from("./out"));
 
-        let _messages = super::list_messages(&client, rooms.await[1].clone().id, true, false).await;
+        let _messages = super::list_messages(&client, rooms.await[1].clone().id, true, false, PathBuf::from("./out")).await;
     }
 
     fn get_login() -> (String, String) {

--- a/src/ReAPI/saved_posts.rs
+++ b/src/ReAPI/saved_posts.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
+
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use log::{info};
+use log::info;
 use super::{images, Client};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,7 +19,7 @@ pub struct SavedPost {
     pub body_text: String,
 }
 
-pub async fn download_saved_posts(client: &Client, image_download: bool) -> Vec<SavedPost> {
+pub async fn download_saved_posts(client: &Client, image_download: bool, out: PathBuf) -> Vec<SavedPost> {
     info!("Getting Saved Posts");
 
     let mut after_token = String::new();
@@ -56,6 +58,7 @@ pub async fn download_saved_posts(client: &Client, image_download: bool) -> Vec<
                         images::get_image(
                             &client,
                             url.to_string(),
+                            out.clone(),
                             &std::path::PathBuf::from("./out/saved_posts/images"),
                         )
                         .await;

--- a/src/ReAPI/subreddit.rs
+++ b/src/ReAPI/subreddit.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::{images, Client};
 use log::info;
 use serde::{Deserialize, Serialize};
@@ -21,6 +23,7 @@ pub async fn download_subreddit(
     client: &Client,
     subreddit_name: String,
     image_download: bool,
+    out: PathBuf,
 ) -> Vec<Post> {
     info!("Getting subreddit");
 
@@ -60,6 +63,7 @@ pub async fn download_subreddit(
                         images::get_image(
                             &client,
                             url.to_string(),
+                            out.clone(),
                             &std::path::PathBuf::from("./out/subreddit/images"),
                         )
                         .await;

--- a/src/ReAPI/users.rs
+++ b/src/ReAPI/users.rs
@@ -1,6 +1,6 @@
 use super::Client;
 use cached::SizedCache;
-use log::{debug};
+use log::debug;
 
 #[derive(Clone, Debug)]
 pub struct User {

--- a/src/image_log.rs
+++ b/src/image_log.rs
@@ -1,9 +1,11 @@
 //! This serves the purpose to keep track of images donwloaded to prevenet duplicates between runs
 
 use cached::proc_macro::cached;
+use std::hash;
 use std::{path::PathBuf, fs::OpenOptions};
 use std::io::Write;
 use log::info;
+use std::collections::HashSet;
 
 /// Ensures that the log file exists and returns the initial reading.
 pub fn init(out: PathBuf) -> std::string::String {
@@ -36,4 +38,14 @@ pub fn write_image_log(out: PathBuf, url: String) {
         .expect("Error writing to image log");
 
     writeln!(file, "{}", url).expect("Error writing to image log");
+}
+
+/// Checks if a entry exists in our log
+pub fn check_image_log(out: PathBuf, url: String) -> bool{
+    let binding = std::fs::read_to_string(out.join("imageLog.txt")).expect("Error reading Image Log");
+    let image_log: Vec<String> = binding.split('\n').map(|line| line.to_string()).collect();
+    
+    let hash_set: HashSet<&String> = image_log.iter().collect();
+
+    return hash_set.contains(&url);
 }

--- a/src/image_log.rs
+++ b/src/image_log.rs
@@ -1,0 +1,39 @@
+//! This serves the purpose to keep track of images donwloaded to prevenet duplicates between runs
+
+use cached::proc_macro::cached;
+use std::{path::PathBuf, fs::OpenOptions};
+use std::io::Write;
+use log::info;
+
+/// Ensures that the log file exists and returns the initial reading.
+pub fn init(out: PathBuf) -> std::string::String {
+    info!("Initializing Image Log");
+
+    if !out.join("imageLog.txt").exists() {
+        std::fs::write(out.join("imageLog.txt"), "").expect("Error creating image log")
+    }
+
+    let image_log_contents = std::fs::read_to_string(out.join("imageLog.txt")).unwrap();
+
+    return image_log_contents;
+}
+
+/// Gets the contents of the image log and returns it as a vector
+#[cached]
+pub fn read_image_log(out: PathBuf) -> Vec<String> {
+    let binding = std::fs::read_to_string(out.join("imageLog.txt")).expect("Error reading Image Log");
+    let image_log: Vec<String> = binding.split('\n').map(|line| line.to_string()).collect();
+
+    return image_log
+}
+
+/// Writes to the image log
+pub fn write_image_log(out: PathBuf, url: String) {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .append(true)
+        .open(out.join("imageLog.txt"))
+        .expect("Error writing to image log");
+
+    writeln!(file, "{}", url).expect("Error writing to image log");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod ReAPI;
 mod cli;
 mod export;
 mod macros;
+mod image_log;
 
 use cli::{Cli, Parser};
 
@@ -43,7 +44,7 @@ async fn main() {
         images,
         out,
         debug,
-        noUsernames
+        noUsernames,
     } = args.command
     {
         // Initialize
@@ -56,7 +57,7 @@ async fn main() {
         }
 
         // Get list of rooms
-        let rooms = ReAPI::download_rooms(&client, images, noUsernames).await;
+        let rooms = ReAPI::download_rooms(&client, images, noUsernames, out.clone()).await;
 
         // Exports messages to files.
         let export_formats: Vec<&str> = formats.split(",").collect();
@@ -78,7 +79,7 @@ async fn main() {
         images,
         out,
         debug,
-        noUsernames
+        noUsernames,
     } = args.command
     {
         // Initialize
@@ -91,7 +92,7 @@ async fn main() {
         }
 
         // Gets saved posts
-        let saved_posts = ReAPI::download_saved_posts(&client, images);
+        let saved_posts = ReAPI::download_saved_posts(&client, images, out.clone());
 
         let saved_posts = saved_posts.await;
 
@@ -107,7 +108,7 @@ async fn main() {
         images,
         out,
         debug,
-        noUsernames
+        noUsernames,
     } = args.command
     {
         // Initialize
@@ -119,7 +120,7 @@ async fn main() {
             std::fs::create_dir(out.join("subreddit/images").clone()).unwrap();
         }
         // Gets saved posts
-        let subreddit = ReAPI::download_subreddit(&client, name, images);
+        let subreddit = ReAPI::download_subreddit(&client, name, images, out.clone());
 
         let subreddit = subreddit.await;
 
@@ -230,6 +231,9 @@ async fn init(debug: bool, token: bool, images: bool, out: PathBuf, auth: bool) 
     if !out.exists() {
         std::fs::create_dir(out.clone()).unwrap();
     }
+
+    // Initialize the image log
+    image_log::init(out.clone());
 
     return client;
 }


### PR DESCRIPTION
When running rexit mutiple times it would normally download all the images again, but now it will only download the new images.