### PR TITLE
fix: update outdated Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1294,7 +1294,7 @@ dependencies = [
 
 [[package]]
 name = "rexit"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "cached",
  "chrono",


### PR DESCRIPTION
`Cargo.lock` needs to be updated when the version is bumped.

To expand on why not doing this is an issue: [I build Rexit using `nix`](https://git.kempkens.io/daniel/nix-overlay/src/commit/a3fa62dfb08288626a530248d0f0002b84a21e13/packages/rexit.nix) and that currently fails because one of the things that `nix` does it add the `--frozen` flag to `cargo build`. That currently results in:

```
...
       > error: the lock file /build/source/Cargo.lock needs to be updated but --frozen was passed to prevent this
       > If you want to try to generate the lock file without accessing the network, remove the --frozen flag and use --offline instead.
```